### PR TITLE
Update application to dotnet version and make it self contained

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.x
+        dotnet-version: 8.x
 
     - name: Test with dotnet
       run: dotnet test --configuration Release
@@ -36,7 +36,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.x
+        dotnet-version: 8.x
 
     - name: Publish with dotnet
       run: dotnet publish src/Cmf.Tools.TestDetector.Console/Cmf.Tools.TestDetector.Console.csproj --output win-64x/ -r win-x64 --self-contained --configuration Release /p:PublishSingleFile=true /p:UseAppHost=true /p:Version=$(git describe --tags --dirty)

--- a/src/Cmf.Tools.TestDetector.Console/Cmf.Tools.TestDetector.Console.csproj
+++ b/src/Cmf.Tools.TestDetector.Console/Cmf.Tools.TestDetector.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cmf.Tools.TestDetector.Console/Cmf.Tools.TestDetector.Console.csproj
+++ b/src/Cmf.Tools.TestDetector.Console/Cmf.Tools.TestDetector.Console.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cmf.Tools.TestDetector/Cmf.Tools.TestDetector.csproj
+++ b/src/Cmf.Tools.TestDetector/Cmf.Tools.TestDetector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Company>Critical Manufacturing</Company>
     <Product>CMF Dev Test Detector</Product>
     <Authors>Critical Manufacturing</Authors>

--- a/tests/Cmf.Tools.TestDetector.UnitTests/Cmf.Tools.TestDetector.UnitTests.csproj
+++ b/tests/Cmf.Tools.TestDetector.UnitTests/Cmf.Tools.TestDetector.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Update application to dotnet version 8.

Make the application self-contained. This change is ideal because in 2 years, when we start using dotnet 10, we won't have issues running pipelines CoreBiz-PR and MesBiz-PR with the error:

System.IO.FileNotFoundException
File name: 'System.Runtime, Version=10.0.0.0'

This is the issue we are currently handling (but for the Version=8.0.0.0)